### PR TITLE
Add taxon name filter to get individualGroups

### DIFF
--- a/src/specification/paths/individualGroups/get/description.md
+++ b/src/specification/paths/individualGroups/get/description.md
@@ -1,1 +1,2 @@
-Makes it possible to fetch an individualGroup based on catalogedUnit.catalogNumber
+Makes it possible to fetch an individualGroup based on
+catalogedUnit.catalogNumber OR identification.identifiedTaxonNameStandardized

--- a/src/specification/paths/individualGroups/get/index.json
+++ b/src/specification/paths/individualGroups/get/index.json
@@ -9,9 +9,17 @@
       "name": "filter[catalogNumber]",
       "in": "query",
       "description": "catalog number used to filter individualGroups",
-      "required": true,
+      "required": false,
       "type": "string",
-      "example": "some-catalog-number"
+      "example": "123456"
+    },
+    {
+      "name": "filter[identifiedTaxonNameStandardized]",
+      "in": "query",
+      "description": "Standardized taxon name used to filter individualGroups",
+      "required": false,
+      "type": "string",
+      "example": "Chironectes minimus"
     },
     {
       "name": "include",


### PR DESCRIPTION
This PR adds query `filter[identifiedTaxonNameStandardized]` to GET /individualGroups.