### PR TITLE
Make identificationText not required

### DIFF
--- a/src/specification/models/identification/index.json
+++ b/src/specification/models/identification/index.json
@@ -40,6 +40,5 @@
       "example": true
     },
     "version": { "type": "integer" }
-  },
-  "required": ["identificationText"]
+  }
 }


### PR DESCRIPTION
This field was removed in the latest form iteration